### PR TITLE
Fixing issue with newer automakes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,6 @@ AC_DEFINE(SVN_REVISION, "gitrev", [SVN Revision])
 AC_CONFIG_SRCDIR([config.h.in])
 AC_CONFIG_HEADERS([config.h])
 # AC_CONFIG_AUX_DIR([build-aux])
-AM_INIT_AUTOMAKE
 
 AC_ARG_VAR(PYTHON, [python program])
 


### PR DESCRIPTION
Newer versions of automake don't tolerate multiple uses of AM_INIT_AUTOMAKE

Removing the first seems to satisfy it.